### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,7 @@ required arguments:
 ```
 
 ## TODO
-- [ ] logging
+- [ ] Logging module
+- [ ] Object reprs
+- [ ] More intuitive configuration for simulated sequencing depth/coverage
+- [ ] More detailed description in README

--- a/io_tools/formatter.py
+++ b/io_tools/formatter.py
@@ -67,7 +67,7 @@ def fmt_met_calls(
     # Throw error if parameter values are not as expected.
     if pos_start not in [0, 1]:
         raise ValueError("Chromosomal position value must be 0-based or 1-based.")
-    elif cols[6] == 999 and isinstance(met_reads_col, int):
+    elif int(cols[5]) != 999 or not isinstance(int(met_reads_col), int):
         raise ValueError(
             "Methylation level has been indicated to not be present in the input raw methylation "
             + "calls file, but the methylation read count column index has not been properly "
@@ -75,7 +75,7 @@ def fmt_met_calls(
         )
 
     # Initialize new header, remove context column if mammalian data.
-    new_header: List[str] = ["chrom", "0-pos", "strand", "context", "coverage" "methylation_level"]
+    new_header: List[str] = ["chrom", "0-pos", "strand", "context", "coverage", "methylation_level"]
     _rm_context_col(mammal, 3, new_header)
 
     # Set output file path.

--- a/io_tools/parsers.py
+++ b/io_tools/parsers.py
@@ -5,8 +5,8 @@ import json
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+from Bio import SeqIO
 from Bio.Seq import Seq
-from Bio.SeqIO.FastaIO import SimpleFastaParser
 
 
 def parse_config(config_fpath: Path) -> dict:
@@ -41,7 +41,7 @@ def parse_fasta(fasta_fpath: Path) -> Dict[str, Seq]:
     """
     with fasta_fpath.open() as f:
         contig_seq: Dict[str, Seq] = dict(
-            (contig, seq) for contig, seq in SimpleFastaParser(f)
+            (seq_record.id, seq_record.seq) for seq_record in SeqIO.parse(f, "fasta")
         )
 
     return contig_seq
@@ -67,6 +67,7 @@ def parse_met_call(met_calls_fpath: Path) -> Dict[str, Tuple[Dict[int, int], Dic
     with met_calls_fpath.open() as f:
         rdr = csv.reader(f, delimiter="\t")
         met_calls: Dict[str, Tuple[Dict[int, int], Dict[int, int]]] = {}
+        next(rdr)  # skip header
 
         # Read through file.
         line: List[str]

--- a/remsim.py
+++ b/remsim.py
@@ -21,18 +21,27 @@ def main(config_fpath: Path) -> None:
 
     # Run formatter with formatter settings.
     fmt_conf: dict = config["formatter"]
+
+    print("Begin formatting...")  # TODO: [Logging]:: move to logger
+
     met_calls_fpath: Path = fmt(
         fmt_conf["mammal"],
         fmt_conf["minimum_coverage"],
         fmt_conf["start_position"],
+        fmt_conf["cols_idx"],
         Path(fmt_conf["raw_methylation_calls"]),
         Path(fmt_conf["intermediate_dir"]),
         fmt_conf["met_reads_col_idx"],
     )
 
+    print("Formatting end.\n")  # TODO: [Logging]:: move to logger
+    print("Reading reference genome and processed methylation calls...")
+
     # Store reference genome fasta info and methylation calls info by chromosome in dictionaries.
     chrom_seq: Dict[str, Seq] = fa_parser(Path(config["reference"]))
     chrom_met_calls: Dict[str, Tuple[Dict[int, int], Dict[int, int]]] = met_parser(met_calls_fpath)
+
+    print("Creating simulator objects...")  # TODO: [Logging]:: move to logger
 
     # Generate new process for each chromosome to simulate separately.
     sim_conf: dict = config["simulator"]  # simulator params
@@ -46,10 +55,12 @@ def main(config_fpath: Path) -> None:
             read_len=sim_conf["read_length"],
             insert_mu=sim_conf["mean_insert_size"],
             insert_sigma=sim_conf["insert_size_standard_deviation"],
-            output_dir=sim_conf["output_dir"],
+            output_dir=Path(sim_conf["output_dir"]),
         )
         sim_proc: Process = Process(target=simulator.sim_all_reads, args=())
         processes[key] = (simulator, sim_proc)
+
+    print("Simulation start...")  # TODO: [Logging]:: move to logger
 
     # Start processes.
     sim_proc: Tuple[Simulator, Process]
@@ -59,6 +70,8 @@ def main(config_fpath: Path) -> None:
     # Exit completed processes.
     for sim_proc in processes.values():
         sim_proc[1].join()
+
+    print("Simulation end.\n")  # TODO: [Logging]:: move to logger
 
 
 if __name__ == "__main__":

--- a/simulator/simulator.py
+++ b/simulator/simulator.py
@@ -80,22 +80,34 @@ class Simulator:
         """Simulate all read pairs and write to file."""
         simmed_reads: int = 0  # accumulator
         while simmed_reads <= self.num_reads:
+            # TODO: [Logging]:: move to logger.
+            print("Number of simmed reads: {}".format(simmed_reads))
+
             curr_read_pair: ReadPair = self._sim_read()  # sim read pair
 
             # If pair is discarded, continue loop without updating accumulator.
             if curr_read_pair is None:
+                print("Discard\n")  # TODO: [Logging]:: move to logger
                 continue
 
             # Create Read objects for each read in the pair.
             read1: Read = curr_read_pair.create_read(self.chrom, 0, self.sequence)
             read2: Read = curr_read_pair.create_read(self.chrom, 1, self.sequence)
 
+            # TODO: [Logging]:: move to logger.
+            print("Accept")
+            print("Chrom: {}, strand: {}".format(read1.chrom, read1.strand))
+            print("Read 1: {} - {}".format(read1.start, read1.end))
+            print("Read 1 number of met sites: {}".format(len(read1.met_calls)))
+            print("Read 2: {} - {}".format(read2.start, read2.end))
+            print("Read 2 number of met sites: {}\n".format(len(read2.met_calls)))
+
             # Write read entry to output fastq file.
             with self.fq_1.open(mode="a") as f1, self.fq_2.open(mode="a") as f2:
                 f1.write(read1.fastq_entry())
                 f2.write(read2.fastq_entry())
 
-            simmed_reads += 1  # update accumulator
+            simmed_reads += 2  # update accumulator
 
     def _sim_read(self) -> Optional[ReadPair]:
         """
@@ -111,8 +123,8 @@ class Simulator:
 
         # Simulate read properties.
         strand: int = random.randint(0, 1)
-        read1_start: int = random.randint(0, self.length)
-        insert_size: int = round(normal(self.insert_mu, self.insert_sigma, 1)[0])
+        read1_start: int = random.randint(0, self.seq_len)
+        insert_size: int = int(round(normal(self.insert_mu, self.insert_sigma, 1)[0]))
 
         # Set direction as per the strand.
         directed_read_len: int = -self.read_len if strand else self.read_len


### PR DESCRIPTION
This PR fixes several bugs and adds some logging prints that will eventually be moved to the logging module. README has also been updated accordingly.

# CHANGELOG
**Formatter**
* Fixed incorrect error throwing logic in the methylation calls formatter.

**Parsers**
* Processed methylation call file parser now correctly skips the header line.
* Fasta parser switched to Biopython SeqIO general parser from SimpleFasterParser.

**Simulator**
* Chromosome length correctly assigned.
* Accumulator now correctly updates by 2 (since each iteration simulates a pair of reads).
* Insert gap being drawn from a normal distribution now correctly returns an integer value.

**Read**
* Methylation calls now correctly initiated.
* Sequence and quality lines in the fastq output is now correctly ordered.
* Sequence methylation update now correctly determines the position index relative to the read start position.
* Methylation call positions now added to the read name line.

**Main**
* Output directory is now correctly converted to a Path object.