### PR TITLE
VEF Mode

### DIFF
--- a/base/__init__.py
+++ b/base/__init__.py
@@ -1,0 +1,2 @@
+from .base_simulator import *
+from .base_read import *

--- a/base/base_read.py
+++ b/base/base_read.py
@@ -1,0 +1,100 @@
+# base_read.py
+
+from abc import abstractmethod
+from typing import Dict, List, NoReturn, Tuple, Union
+
+
+class BaseRead:
+    """
+    Base class for a bisulfite-sequencing read.
+
+    Attributes
+    ----------
+    source : str
+        The source of the simulation.
+
+    chrom : str
+        The chromosome the read is one.
+
+    strand : int
+        The strand the read is one. 0 for forward, 1 for reverse.
+
+    start_end : tuple of int
+        The start and end positions of the read. [start, end)
+
+    met_calls : dict of {int, int}
+        A dictionary of methylation calls. Positional keys and methylation state values.
+    """
+
+    def __init__(
+        self,
+        source: str,
+        chrom: str,
+        strand: int,
+        start_end: Tuple[int, int],
+        met_calls: Dict[int, int],
+    ) -> None:
+        self.source: str = source
+        self.chrom: str = chrom
+        self.strand: int = strand
+        self.read_start: int = start_end[0]
+        self.read_end: int = start_end[1]
+        self.met_calls: Dict[int, int] = met_calls
+
+    # TODO: [repr]:: add repr method to BaseRead
+
+
+class BaseReadPair:
+    """
+    Base class for a pair of paired-end reads on the same strand.
+
+    Attributes
+    ----------
+    source : str
+        The source of the simulation.
+
+    chrom : str
+        The chromosome the read pair is on.
+
+    strand : int
+        The strand the read pair is on. 0 for forward, 1 for reverse.
+
+    reads : tuple of tuple of int
+        A tuple of the read start-end position tuples.
+
+    read_met_calls : tuple of dict of {int, int}
+        Methylation states at methylation sites within each of the reads.
+
+    Methods
+    -------
+    entry()
+        Create output file entry/entries for the read pair.
+    """
+
+    def __init__(
+        self,
+        source: str,
+        chrom: str,
+        strand: int,
+        reads: Tuple[Tuple[int, int], Tuple[int, int]],
+        read_met_calls: Tuple[Dict[int, int], Dict[int, int]],
+    ) -> None:
+        self.source: str = source
+        self.chrom: str = chrom
+        self.strand: int = strand
+        self.reads: Tuple[Tuple[int, int], Tuple[int, int]] = reads
+        self.read_met_calls: Tuple[Dict[int, int], Dict[int, int]] = read_met_calls
+
+    @abstractmethod
+    def entry(self) -> Union[NoReturn, Tuple[str, str], str]:
+        """
+        Creates the VEF entry/FASTQ entries for the read pair.
+
+        Raises
+        ------
+        NotImplementedError
+            If not implemented in child class.
+        """
+        raise NotImplementedError
+
+    # TODO: [repr]:: add repr method to BaseReadPair.

--- a/base/base_simulator.py
+++ b/base/base_simulator.py
@@ -1,0 +1,189 @@
+# base_simulator.py
+
+from abc import abstractmethod
+import random
+import time
+from pathlib import Path
+from typing import Dict, NoReturn, Optional, Tuple, Union
+
+from Bio.Seq import Seq
+from numpy.random import normal
+
+from .base_read import BaseRead, BaseReadPair
+import utils.util as util
+
+
+class BaseSimulator:
+    """
+    Base simulator class.
+
+    Attributes
+    ----------
+    chrom : str
+        The chromosome to simulate data from.
+
+    chrom_met_calls : tuple of dict of {int, int}
+        Methylation sites and states for each strand of the current chromosome.
+
+    num_reads : int
+        Number of read pairs to simulate.
+
+    read_len : int
+        Length of the simulated reads.
+
+    inner_dist_mu : float
+        User designated mean of the inner distance.
+
+    inner_dist_sigma : float
+        User designated standard deviation of the inner distance.
+
+    window_start : int (optional)
+        The start position (0-based) of the window to simulate reads from. If not specified, set to
+        beginning of chromosome.
+
+    window_end : int (optional)
+        The end position (0-based) of the window to simulate reads from. If not specified, set to
+        the end of the chromosome.
+
+    Methods
+    -------
+    sim_all_Reads()
+        Simulate all read pairs.
+    """
+
+    def __init__(
+        self,
+        source: str,
+        chrom: str,
+        chrom_seq: Seq,
+        chrom_met_calls: Tuple[Dict[int, int]],
+        num_reads: int,
+        read_len: int,
+        inner_dist_mu: int,
+        inner_dist_sigma: int,
+        output_dir: Path,
+        window_start: int = 0,
+        sim_window: int = 0,
+    ) -> None:
+        # Simulation source information.
+        self.chrom: str = chrom
+        self.chrom_seq: Seq = chrom_seq
+        self.met_calls = chrom_met_calls
+        self.window_start: int = window_start
+
+        if sim_window:  # if not 0
+            self.window_end: int = self.window_start + sim_window
+        else:
+            self.window_end = len(chrom_seq) - 1
+
+        # Output file paths.
+        self.source: str = source
+        self.output_dir: Path = output_dir
+        util.ensure_dir(output_dir)
+        self._set_output_file_path()
+
+        # Read simulation properties.
+        self.num_reads: int = num_reads
+        self.read_len: int = read_len
+        self.inner_dist_mu: int = inner_dist_mu  # mean inner distance
+        self.inner_dist_sigma: int = inner_dist_sigma  # inner distance standard deviation
+
+    @abstractmethod
+    def sim_all_reads(self, *kwargs) -> Optional[NoReturn]:
+        """
+        Simulate all read pairs and write to file.
+
+        Raises
+        ------
+        NotImplementedError
+            If not implemented in child class.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _set_output_file_path(self) -> Optional[NoReturn]:
+        """
+        Set output file path.
+
+        Raises
+        ------
+        NotImplementedError
+            If not implemented in child class.
+        """
+        raise NotImplementedError
+
+    def _sim_properties(
+        self
+    ) -> Optional[
+        Tuple[int, Tuple[Tuple[int, int], Tuple[int, int]], Tuple[Dict[int, int], Dict[int, int]]]
+    ]:
+        """"""
+        random.seed(time.time())  # seed current time
+
+        # Simulate read properties.
+        strand: int = random.randint(0, 1)
+        read1_start: int = random.randint(self.window_start, self.window_end)
+        inner_distance: int = int(round(normal(self.inner_dist_mu, self.inner_dist_sigma, 1)[0]))
+
+        # Set direction as per the strand. 0 = forward, 1 = reverse.
+        directed_read_len: int = -self.read_len if strand else self.read_len
+        directed_inner_dist: int = -inner_distance if strand else inner_distance
+
+        # Early guard against simulation window boundaries. Discard if bounds are violated.
+        read2_end: int = read1_start + directed_inner_dist + (2 * directed_read_len)
+        if read2_end < self.window_start or read2_end > (self.window_end + 1):
+            return None
+
+        # Set rest of the read values.
+        reads: Tuple[Tuple[int, int], Tuple[int, int]] = (
+            (read1_start, read1_start + directed_read_len),
+            (read2_end - directed_read_len, read2_end),
+        )
+
+        # Ensure ascending positional order (for start and end) for reverse strand.
+        if strand:
+            reads = (util.reverse_tuple_pair(reads[0]), util.reverse_tuple_pair(reads[1]))
+
+        # Extract subset of methylation calls covered by reads.
+        read_met_calls: Tuple[Dict[int, int], Dict[int, int]] = self._subset_met_calls(
+            strand, reads
+        )
+
+        return strand, reads, read_met_calls
+
+    @abstractmethod
+    def _sim_read(self) -> Union[NoReturn, Optional[BaseReadPair]]:
+        """
+        Simulate a pair of paired-end reads.
+
+        Returns
+        -------
+        base.BaseReadPair or None
+            A BaseReadPair if the read coordinates remain within simulation window boundaries. None
+            otherwise.
+        """
+        raise NotImplementedError
+
+    def _subset_met_calls(
+        self, strand: int, reads: Tuple[Tuple[int, int], Tuple[int, int]]
+    ) -> Tuple[Dict[int, int], Dict[int, int]]:
+        """
+        Discover the subset of methylation calls within a pair of paired end reads.
+
+        Parameters
+        ----------
+        strand : int
+            The strand the read pair is on. 0 for forward, 1 for reverse.
+
+        reads : tuple of tuple of int
+            A tuple of the read start-end position tuples.
+
+        Returns
+        -------
+        tuple of dict of {int, int}
+            Dictionaries of position to methylation state of all positions within the paired reads.
+        """
+        return (
+            util.subset_dict(reads[0], self.met_calls[strand]),
+            util.subset_dict(reads[1], self.met_calls[strand]),
+        )

--- a/examples/example_config.json
+++ b/examples/example_config.json
@@ -3,6 +3,7 @@
         "mammal": true,
         "minimum_coverage": 1,
         "start_position": 0,
+        "cols_idx": [0, 1, 2, 3, 4, 5],
         "raw_methylation_calls": "examples/raw_met_calls.tsv",
         "intermediate_dir": "examples/",
         "met_reads_col_idx": null
@@ -15,6 +16,9 @@
         "read_length": 150,
         "mean_insert_size": 50,
         "insert_size_standard_deviation": 5,
-        "output_dir": "examples/output/"
+        "output_dir": "examples/output/",
+        "seq_start": 0,
+        "sim_window": 0,
+        "file_prefix": ""
     }
 }

--- a/examples/example_config.json
+++ b/examples/example_config.json
@@ -12,13 +12,14 @@
     "reference": "examples/reference.fa",
 
     "simulator": {
+        "mode": "vef",
+        "source": "example",
         "read_count": 1000,
         "read_length": 150,
-        "mean_insert_size": 50,
-        "insert_size_standard_deviation": 5,
+        "mean_inner_distance": 50,
+        "inner_distance_standard_deviation": 5,
         "output_dir": "examples/output/",
         "seq_start": 0,
-        "sim_window": 0,
-        "file_prefix": ""
+        "sim_window": 0
     }
 }

--- a/io_tools/formatter.py
+++ b/io_tools/formatter.py
@@ -2,7 +2,7 @@
 
 import csv
 from pathlib import Path
-from typing import List, NoReturn, Optional, Union
+from typing import List, NoReturn, Optional
 
 from utils.util import ensure_dir
 
@@ -15,7 +15,7 @@ def fmt_met_calls(
     in_fpath: Path,
     out_dpath: Path,
     met_reads_col: Optional[int] = None,
-) -> Union[NoReturn, Path]:
+) -> Optional[NoReturn]:
     """
     Format methylation calls TSV file.
 
@@ -114,8 +114,6 @@ def fmt_met_calls(
                 new_row: list = [chrom, pos, strand, context, coverage, methylation_state]
                 _rm_context_col(mammal, 3, new_header)
                 wtr.writerow(new_row)
-
-    return out_fpath
 
 
 def _rm_context_col(mammal: bool, context_col_idx: int, row: list) -> None:

--- a/remsim.py
+++ b/remsim.py
@@ -45,6 +45,13 @@ def main(config_fpath: Path) -> None:
 
     # Generate new process for each chromosome to simulate separately.
     sim_conf: dict = config["simulator"]  # simulator params
+    try:
+        seq_start: int = sim_conf["seq_start"]
+        sim_window: int = sim_conf["sim_window"]
+    except KeyError:
+        seq_start = 0
+        sim_window = 0
+
     processes: Dict[str, Tuple[Simulator, Process]] = {}
     for key in chrom_seq.keys():
         simulator = Simulator(
@@ -56,6 +63,9 @@ def main(config_fpath: Path) -> None:
             insert_mu=sim_conf["mean_insert_size"],
             insert_sigma=sim_conf["insert_size_standard_deviation"],
             output_dir=Path(sim_conf["output_dir"]),
+            seq_start=seq_start,
+            sim_window=sim_window,
+            file_prefix=sim_conf["file_prefix"]
         )
         sim_proc: Process = Process(target=simulator.sim_all_reads, args=())
         processes[key] = (simulator, sim_proc)

--- a/remsim.py
+++ b/remsim.py
@@ -3,28 +3,23 @@
 import argparse
 from multiprocessing import Process
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, NoReturn, Optional, Tuple
 
 from Bio.Seq import Seq
 
+from base import BaseSimulator
 from io_tools import (
     fmt_met_calls as fmt,
     parse_config,
     parse_fasta as fa_parser,
     parse_met_call as met_parser,
 )
-from simulator import Simulator
+from simulator import FastqSimulator, VefSimulator
 
 
-def main(config_fpath: Path) -> None:
-    config: dict = parse_config(config_fpath)
-
-    # Run formatter with formatter settings.
-    fmt_conf: dict = config["formatter"]
-
-    print("Begin formatting...")  # TODO: [Logging]:: move to logger
-
-    met_calls_fpath: Path = fmt(
+def formatting(fmt_conf: dict) -> None:
+    """"""
+    fmt(
         fmt_conf["mammal"],
         fmt_conf["minimum_coverage"],
         fmt_conf["start_position"],
@@ -34,46 +29,48 @@ def main(config_fpath: Path) -> None:
         fmt_conf["met_reads_col_idx"],
     )
 
-    print("Formatting end.\n")  # TODO: [Logging]:: move to logger
-    print("Reading reference genome and processed methylation calls...")
 
-    # Store reference genome fasta info and methylation calls info by chromosome in dictionaries.
-    chrom_seq: Dict[str, Seq] = fa_parser(Path(config["reference"]))
-    chrom_met_calls: Dict[str, Tuple[Dict[int, int], Dict[int, int]]] = met_parser(met_calls_fpath)
-
-    print("Creating simulator objects...")  # TODO: [Logging]:: move to logger
-
-    # Generate new process for each chromosome to simulate separately.
-    sim_conf: dict = config["simulator"]  # simulator params
+def simulating(
+    sim_conf: dict,
+    chrom_seqs: Dict[str, Seq],
+    chrom_met_calls: Dict[str, Tuple[Dict[int, int], Dict[int, int]]],
+) -> None:
+    """"""
     try:
-        seq_start: int = sim_conf["seq_start"]
+        window_start: int = sim_conf["window_start"]
         sim_window: int = sim_conf["sim_window"]
     except KeyError:
-        seq_start = 0
+        window_start = 0
         sim_window = 0
 
-    processes: Dict[str, Tuple[Simulator, Process]] = {}
-    for key in chrom_seq.keys():
-        simulator = Simulator(
-            chrom=key,
-            seq=chrom_seq[key],
-            chrom_met_calls=chrom_met_calls[key],
-            num_reads=sim_conf["read_count"],
-            read_len=sim_conf["read_length"],
-            insert_mu=sim_conf["mean_insert_size"],
-            insert_sigma=sim_conf["insert_size_standard_deviation"],
-            output_dir=Path(sim_conf["output_dir"]),
-            seq_start=seq_start,
-            sim_window=sim_window,
-            file_prefix=sim_conf["file_prefix"]
-        )
+    sim_input: dict = {
+        "source": sim_conf["source"],
+        "num_reads": sim_conf["read_count"],
+        "read_len": sim_conf["read_length"],
+        "inner_dist_mu": sim_conf["mean_inner_distance"],
+        "inner_dist_sigma": sim_conf["inner_distance_standard_deviation"],
+        "output_dir": Path(sim_conf["output_dir"]),
+        "window_start": window_start,
+        "sim_window": sim_window,
+    }
+
+    processes: Dict[str, Tuple[BaseSimulator, Process]] = {}
+    for key in chrom_seqs.keys():
+        sim_input["chrom"] = key
+        sim_input["chrom_seq"] = chrom_seqs[key]
+        sim_input["chrom_met_calls"] = chrom_met_calls[key]
+
+        if sim_conf["mode"] == "fastq":
+            simulator: BaseSimulator = FastqSimulator(**sim_input)
+        else:
+            simulator = VefSimulator(**sim_input)
         sim_proc: Process = Process(target=simulator.sim_all_reads, args=())
         processes[key] = (simulator, sim_proc)
 
     print("Simulation start...")  # TODO: [Logging]:: move to logger
 
     # Start processes.
-    sim_proc: Tuple[Simulator, Process]
+    sim_proc: Tuple[BaseSimulator, Process]
     for sim_proc in processes.values():
         sim_proc[1].start()
 
@@ -81,7 +78,43 @@ def main(config_fpath: Path) -> None:
     for sim_proc in processes.values():
         sim_proc[1].join()
 
-    print("Simulation end.\n")  # TODO: [Logging]:: move to logger
+
+def main(config_fpath: Path, function: str) -> Optional[NoReturn]:
+    """
+    """
+    config: dict = parse_config(config_fpath)
+    if function not in ["format", "simulate"]:
+        raise ValueError('Invalid function specified, please enter "format" or "simulate"')
+
+    fmt_conf: dict = config["formatter"]
+    if function == "format":
+        print("Begin formatting...")  # TODO: [Logging]:: move to logger
+        formatting(fmt_conf)
+        print("Formatting end.\n")  # TODO: [Logging]:: move to logger
+
+    else:
+        if config["simulator"]["mode"] not in ["vef", "fastq"]:
+            raise ValueError(
+                'Invalid simulation mode specified, please use either "vef" or "fastq"'
+            )
+
+        out_dpath: Path = Path(fmt_conf["intermediate_dir"])
+        in_fpath: Path = Path(fmt_conf["raw_methylation_calls"])
+        met_calls_fpath: Path = out_dpath.joinpath("processed_" + in_fpath.name)
+
+        # Store reference genome fasta info and methylation calls info by chromosome in
+        # dictionaries.
+        print("Reading reference genome and processed methylation calls...")
+        chrom_seqs: Dict[str, Seq] = fa_parser(Path(config["reference"]))
+        chrom_met_calls: Dict[str, Tuple[Dict[int, int], Dict[int, int]]] = met_parser(
+            met_calls_fpath
+        )
+
+        # Generate new process for each chromosome to simulate separately.
+        sim_conf: dict = config["simulator"]  # simulator params
+        print("Creating simulator objects...")  # TODO: [Logging]:: move to logger
+        simulating(sim_conf, chrom_seqs, chrom_met_calls)
+        print("Simulation end.\n")  # TODO: [Logging]:: move to logger
 
 
 if __name__ == "__main__":
@@ -93,7 +126,10 @@ if __name__ == "__main__":
         default=None,
         type=str,
         help="Configuration JSON file path.",
-        required=True
+        required=True,
+    )
+    required.add_argument(
+        "-f", "--function", default=None, type=str, help="Function to perform.", required=True
     )
 
-    main(Path(args.parse_args().config))
+    main(Path(args.parse_args().config), args.parse_args().function)


### PR DESCRIPTION
This PR adds VEF mode to the simulator. Instead of FastQ files, the user may use VEF mode to generate VEF files.

The VEF (variant encoding file) is a tab-delimited file with the following format:
```
@Haplotype_<source organism>_chrom<chromosome>_<forward or reverse>_strand:<read 1 start>_<read2_start>    <read variant 1 position>=<reference (0) or alternate (1) allele>;<variant 2 position>=<0 or 1>;...;<variant n>=<0 or 1>;    //    <read 1 start>    <read 1 end>    <read 2 start>    <read 2 end>
```

This PR also separates the raw methylation calls formatter and the simulation functions. Users must now specify "format" or "simulate" when using the program.